### PR TITLE
Configure server path prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,3 @@ ADD init-and-run-wiki /usr/local/bin/init-and-run-wiki
 
 # Meta
 CMD ["/usr/local/bin/init-and-run-wiki"]
-EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -56,3 +56,12 @@ If you are in a memory-constrained environment, you can provide the
 
 Set the `DEBUG_LEVEL` environment variable to `debug`. For example by passing
 `-e DEBUG_LEVEL=debug` option in `docker run`.
+
+### Path prefix
+
+Set the `PATH_PREFIX` environment variable to customize the path prefix for
+serving TiddlyWiki. For example by passing `-e PATH_PREFIX=\wiki` option in
+`docker run`. According to this [note][path-prefix-note], please remember to
+configure the client as well.
+
+[path-prefix-note]: https://tiddlywiki.com/static/Using%2520a%2520custom%2520path%2520prefix%2520with%2520the%2520client-server%2520edition.html

--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -19,6 +19,9 @@ fi
 # Configure listen command, see https://tiddlywiki.com/static/ListenCommand.html
 listen_params="host=0.0.0.0 port=8080"
 listen_params="$listen_params debug-level=${DEBUG_LEVEL-none}"
+if [ -n "$PATH_PREFIX" ]; then
+  listen_params="$listen_params path-prefix=$PATH_PREFIX"
+fi
 if [ -n "$USERNAME" ]; then
   listen_params="$listen_params username=$USERNAME"
   listen_params="$listen_params password=${PASSWORD-wiki}"

--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -16,10 +16,13 @@ if [ ! -d /var/lib/tiddlywiki/mywiki ]; then
   mkdir /var/lib/tiddlywiki/mywiki/tiddlers
 fi
 
+# Configure listen command, see https://tiddlywiki.com/static/ListenCommand.html
+listen_params="host=0.0.0.0 port=8080"
+listen_params="$listen_params debug-level=${DEBUG_LEVEL-none}"
+if [ -n "$USERNAME" ]; then
+  listen_params="$listen_params username=$USERNAME"
+  listen_params="$listen_params password=${PASSWORD-wiki}"
+fi
 
 # Start the tiddlywiki server
-if [ -z "$USERNAME" ]; then
-    exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --listen host=0.0.0.0 port=8080 debug-level=${DEBUG_LEVEL-none};
-else
-    exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --listen host=0.0.0.0 port=8080 username="$USERNAME" password="${PASSWORD-wiki}" debug-level=${DEBUG_LEVEL-none};
-fi
+exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --listen $listen_params


### PR DESCRIPTION
Hi @m0wer, thanks for maintaining this.

I saw that the project used to support similar thing via the `SERVE_URI` env var, I wonder if we could have it back via the new `path-prefix` parameter in listen command.

What do you think?