### PR TITLE
allow extra options via environment variables

### DIFF
--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -28,4 +28,4 @@ if [ -n "$USERNAME" ]; then
 fi
 
 # Start the tiddlywiki server
-exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --listen $listen_params
+exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --listen $listen_params $EXTRAOPTIONS


### PR DESCRIPTION
For example, when using https://github.com/OokTech/TW5-Bob you need the option `--wsserver`.  This will allow you to do `EXTRAOPTIONS=--wsserver`.